### PR TITLE
Fix error illegal use of reserved word `highp'

### DIFF
--- a/demo.js
+++ b/demo.js
@@ -146,7 +146,7 @@ function mozSetup(gl) {
   // Fragment shader program
 
   const fsSource = `
-    uniform highp vec4 uColour;
+    uniform vec4 uColour;
     void main() {
       gl_FragColor = uColour;
     }


### PR DESCRIPTION
I don't know about shaders, but if I just remove the keyword `highp` the demo runs for me.

Error message
```
An error occurred compiling the shaders: 0:2(10): error: illegal use of reserved word `highp'
0:2(10): error: syntax error, unexpected ERROR_TOK
```